### PR TITLE
Compatibility with bluetooth-serial-port 1.0.0 and above

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -218,7 +218,10 @@ OBDReader.prototype.connect = function () {
     this.intervalWriter = setInterval(function (){
         if(queue.length > 0 && self.connected)
             try {
-                self.btSerial.write(queue.shift());
+                self.btSerial.write(new Buffer(queue.shift(), "utf-8"), function(err, count) {
+                    if(err)
+                        console.log(err);
+                });
             } catch (err) {
                 console.log('Error while writing: ' + err);
                 console.log('OBD-II Listeners deactivated, connection is probably lost.');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "./lib/obd.js",
   "dependencies": {
-    "bluetooth-serial-port": ">=0.2.x"
+    "bluetooth-serial-port": ">=1.x"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
Version 1.0.0 switched from strings to buffers which breaks the plugin. This adds support for that.

Also, confirmed compatibility with Mac OS 10.8 
