### PR TITLE
add condition of obd returned searching info

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -89,6 +89,7 @@ function parseOBDCommand(hexString) {
         valueArray; //New object
 
     reply = {};
+	if (hexString === "SEARCHING...") return 1;
     if (hexString === "NO DATA" || hexString === "OK" || hexString === "?" || hexString === "UNABLE TO CONNECT") { //No data or OK is the response.
         reply.value = hexString;
         return reply;
@@ -230,7 +231,10 @@ OBDReader.prototype.connect = function (address, channel) {
                         var reply;
                         reply = parseOBDCommand(messageString);
                         //Event dataReceived.
-                        self.emit('dataReceived', reply);
+						if ( reply == 1 ) {
+						}else {
+                        	self.emit('dataReceived', reply);
+						}
                         self.receivedData = '';
                     }
                 }


### PR DESCRIPTION
Sometimes OBD will return "SEARCHING..." firstly, and then return the data source, so add this condition judgment to filter "SEARCHING..." message, otherwise the routine will parse and only return {}.