### PR TITLE
Implement setProtocol/getProtocol methods to specify car communicatio…

### DIFF
--- a/example/test.js
+++ b/example/test.js
@@ -18,6 +18,12 @@
 var OBDReader = require('../lib/obd.js');
 var btOBDReader = new OBDReader();
 
+// Specify the car communications protocol rather than autodetect
+// http://www.obdtester.com/elm-usb-commands
+// e.g.
+// 'ISO 15765-4 CAN (11 bit ID, 500 kbaud)'
+//btOBDReader.setProtocol(6);
+
 btOBDReader.on('dataReceived', function (data) {
     var currentDate = new Date();
     console.log(currentDate.getTime());

--- a/lib/obd.js
+++ b/lib/obd.js
@@ -52,6 +52,7 @@ OBDReader = function () {
     EventEmitter.call(this);
     this.connected = false;
     this.receivedData = "";
+    this.protocol = '0' ;
     return this;
 };
 util.inherits(OBDReader, EventEmitter);
@@ -139,6 +140,33 @@ function parseOBDCommand(hexString) {
 }
 
 /**
+ * Set the protocol version number to use with your car.  Defaults to 0
+ * which is to autoselect.
+ *
+ * Uses the ATSP command - see http://www.obdtester.com/elm-usb-commands
+ *
+ * @default 0
+ * 
+ */
+OBDReader.prototype.setProtocol = function (protocol) {
+    if(protocol.toString().search(/^[0-9]$/) === -1) {
+      throw "setProtocol: Must provide a number between 0 and 9 - refer to ATSP section of http://www.obdtester.com/elm-usb-commands";
+    }
+    this.protocol = protocol;
+}
+
+/**
+ * Get the protocol version number set for this object.  Defaults to 0
+ * which is to autoselect.
+ *
+ * Uses the ATSP command - see http://www.obdtester.com/elm-usb-commands
+ *
+ */
+OBDReader.prototype.getProtocol = function () {
+    return this.protocol;
+}
+
+/**
  * Attempts discovery of and subsequent connection to Bluetooth device and channel
  * @param {string} query Query string to be fuzzy-ish matched against device name/address
  */
@@ -199,8 +227,8 @@ OBDReader.prototype.connect = function (address, channel) {
         self.write('ATAT2');
         //Set timeout to 10 * 4 = 40msec, allows +20 queries per second. This is the maximum wait-time. ATAT will decide if it should wait shorter or not.
         //self.write('ATST0A');
-        //Set the protocol to automatic.
-        self.write('ATSP0');
+        //http://www.obdtester.com/elm-usb-commands
+        self.write('ATSP'+self.protocol);
 
         //Event connected
         self.emit('connected');


### PR DESCRIPTION
Hey Eric,

Would you consider this PR?  

Added a setProtocol/getProtocol method so you can be specific about which car communications protocol to use.  The ELM327 Bluetooth adapter I am using disconnects when I specify ATSP0.  When I specify the particular version for my car, it all works fine.

Let me know if the PR requires any changes.

Damo.

As per ATSP section of the ELM USB Commands Document
http://www.obdtester.com/elm-usb-commands