### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ btOBDReader.autoconnect('obd');
 ```
 ## API
 
-###OBDReader
+### OBDReader
 
 #### Event: ('dataReceived', data)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
